### PR TITLE
style: update default input focus outline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,9 +95,7 @@ const App = () => {
                       pl="30px"
                       borderRadius="32px"
                       borderWidth="1px"
-                      focusBorderColor="brand.700"
                       _placeholder={{ color: 'brand.300' }}
-                      _focus={{ borderColor: 'brand.700' }}
                       fontSize="sm"
                       borderColor="brand.100"
                       color="red.500"

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -1,11 +1,6 @@
 // Imports
 // ========================================================
-import {
-  extendTheme,
-  theme as base,
-  withDefaultColorScheme,
-  withDefaultVariant,
-} from '@chakra-ui/react'
+import { extendTheme, theme as base } from '@chakra-ui/react'
 
 // Configurations
 // ========================================================
@@ -30,7 +25,13 @@ const theme = extendTheme({
       800: '#A3D6FF',
     },
   },
-  components: {},
+  components: {
+    Input: {
+      defaultProps: {
+        focusBorderColor: 'brand.700',
+      },
+    },
+  },
   styles: {
     global: () => ({
       body: {


### PR DESCRIPTION
This PR updates the default border color for `Input` components to `brand.700`